### PR TITLE
u1p3p: only switch from 3 to 1 phase if either a car is loading or re…

### DIFF
--- a/goecheck.sh
+++ b/goecheck.sh
@@ -25,7 +25,7 @@ goecheck(){
 				fwv=$(echo $output | jq -r '.fwv' | grep -Po "[1-9]\d{1,2}")
 				oldcurrent=$(echo $output | jq -r '.amp')
 				current=$(</var/www/html/openWB/ramdisk/llsoll)
-				if (( oldcurrent != $current && $current != 0 )) ; then
+				if (( oldcurrent != $current )) && (( $current != 0 )) ; then
 					if (($fwv >= 40)) ; then
 						curl --silent --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/mqtt?payload=amx=$current > /dev/null
 					else
@@ -48,7 +48,7 @@ goecheck(){
 				fi
 				oldcurrent=$(echo $output | jq -r '.amp')
 				current=$(</var/www/html/openWB/ramdisk/llsoll)
-				if (( oldcurrent != $current && $current != 0 )) ; then
+				if (( oldcurrent != $current )) && (( $current != 0 )) ; then
 					curl --silent --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/api/set?amp=$current > /dev/null
 				fi
 			fi
@@ -76,7 +76,7 @@ goecheck(){
 					fwv=$(echo $output | jq -r '.fwv' | grep -Po "[1-9]\d{1,2}")
 					oldcurrent=$(echo $output | jq -r '.amp')
 					current=$(</var/www/html/openWB/ramdisk/llsolls1)
-					if (( oldcurrent != $current && $current != 0 )) ; then
+					if (( oldcurrent != $current )) && (( $current != 0 )) ; then
 						if (($fwv >= 40)) ; then
 							curl --silent --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/mqtt?payload=amx=$current > /dev/null
 						else
@@ -99,7 +99,7 @@ goecheck(){
 					fi
 					oldcurrent=$(echo $output | jq -r '.amp')
 					current=$(</var/www/html/openWB/ramdisk/llsolls1)
-					if (( oldcurrent != $current && $current != 0 )) ; then
+					if (( oldcurrent != $current )) && (( $current != 0 )) ; then
 						curl --silent --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/api/set?amp=$current > /dev/null
 					fi
 				fi

--- a/u1p3p.sh
+++ b/u1p3p.sh
@@ -222,7 +222,7 @@ u1p3pswitch(){
 										openwbDebugLog "MAIN" 1 "auf 1 Phasen MinPV Automatik geaendert da geringerer Überschuss"
 									fi
 								fi
-								if  (((( oldll == minimalampv )) && (( ladeleistung > 100 )))) || (( uberschuss < 3 * mindestuberschuss )); then
+								if  (( oldll == minimalampv )) && (( ladeleistung > 100 )); then
 									urcounter=$(</var/www/html/openWB/ramdisk/urcounter)
 									if (( urcounter < urwaittime )); then
 										urcounter=$((urcounter + 10))
@@ -316,7 +316,7 @@ u1p3pswitch(){
 										openwbDebugLog "MAIN" 1 "auf 1 Phasen NurPV Automatik geaendert da geringerer Überschuss"
 									fi
 								fi
-								if (((( oldll == minimalapv )) && (( ladeleistung > 100 )))) || ((uberschuss < 3 * mindestuberschuss)); then
+								if (( oldll == minimalapv )) && (( ladeleistung > 100 )); then
 									urcounter=$(</var/www/html/openWB/ramdisk/urcounter)
 									if (( urcounter  < urwaittime )); then
 										urcounter=$((urcounter + 10))

--- a/u1p3p.sh
+++ b/u1p3p.sh
@@ -281,7 +281,7 @@ u1p3pswitch(){
 										openwbDebugLog "MAIN" 1 "auf 3 Phasen NurPV Automatik geaendert"
 									fi
 								fi
-								if (( oldll == maximalstromstaerke )) && (( ladeleistung > 100 )); then
+								if (( oldll == maximalstromstaerke )); then
 									uhcounter=$(</var/www/html/openWB/ramdisk/uhcounter)
 									if (( uhcounter < uhwaittime )); then
 										uhcounter=$((uhcounter + 10))

--- a/u1p3p.sh
+++ b/u1p3p.sh
@@ -222,7 +222,7 @@ u1p3pswitch(){
 										openwbDebugLog "MAIN" 1 "auf 1 Phasen MinPV Automatik geaendert da geringerer Überschuss"
 									fi
 								fi
-								if (( oldll == minimalampv )); then
+								if  (((( oldll == minimalampv )) && (( ladeleistung > 100 )))) || (( uberschuss < 3 * mindestuberschuss )); then
 									urcounter=$(</var/www/html/openWB/ramdisk/urcounter)
 									if (( urcounter < urwaittime )); then
 										urcounter=$((urcounter + 10))
@@ -281,7 +281,7 @@ u1p3pswitch(){
 										openwbDebugLog "MAIN" 1 "auf 3 Phasen NurPV Automatik geaendert"
 									fi
 								fi
-								if (( oldll == maximalstromstaerke )); then
+								if (( oldll == maximalstromstaerke )) && (( ladeleistung > 100 )); then
 									uhcounter=$(</var/www/html/openWB/ramdisk/uhcounter)
 									if (( uhcounter < uhwaittime )); then
 										uhcounter=$((uhcounter + 10))
@@ -316,7 +316,7 @@ u1p3pswitch(){
 										openwbDebugLog "MAIN" 1 "auf 1 Phasen NurPV Automatik geaendert da geringerer Überschuss"
 									fi
 								fi
-								if (( oldll == minimalapv )); then
+								if (((( oldll == minimalapv )) && (( ladeleistung > 100 )))) || ((uberschuss < 3 * mindestuberschuss)); then
 									urcounter=$(</var/www/html/openWB/ramdisk/urcounter)
 									if (( urcounter  < urwaittime )); then
 										urcounter=$((urcounter + 10))


### PR DESCRIPTION
…ally uberschuss isn't enough for 3 phases

WHY: currently if no car is loading and enough uberschuss is there it is continously switched between 1 and 3 phases cause
there are different criterias (1to3: enough uberschuess, 3to1: llsoll==minimalapv)